### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ CFLAGS += -Winit-self -Wstrict-aliasing -fsanitize=address -fno-omit-frame-point
 
 .PHONY: clang
 clang: CC = clang
+clang: CFLAGS = -O3
 clang: $(BIN)
 
 .PHONY: gcc


### PR DESCRIPTION
commit 603beb8 does not work for me because clang cannot support such optimizer flags.
```
clang json.c test.c -g -Wall -Wextra -Wformat=2 -Wunreachable-code -fstack-protector-strong -Winline -Wshadow -Wwrite-strings -fstrict-aliasing -Wstrict-prototypes -Wold-style-definition -Wconversion -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wmissing-prototypes -Wconversion -Wswitch-default -Wundef -Wno-unused -Wstrict-overflow=5 -Wsign-conversion -Winit-self -Wstrict-aliasing -fsanitize=address -fno-omit-frame-pointer -o json
clang: error: unknown argument: '-fstack-protector-strong'
clang: error: unsupported argument 'address' to option 'fsanitize='
make: *** [json] Error 1
```